### PR TITLE
test: smoke-test gate for dependabot security PRs (#43)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -383,6 +383,19 @@ files = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["dev"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
 name = "courlan"
 version = "1.3.2"
 description = "Clean, filter and sample URLs to optimize data collection – includes spam, content type and language filters."
@@ -546,6 +559,18 @@ urllib3 = ">=1.26,<3"
 all = ["htmldate[dev]", "htmldate[speed]"]
 dev = ["black", "flake8", "mypy", "pytest", "pytest-cov", "types-dateparser", "types-lxml", "types-python-dateutil", "types-urllib3"]
 speed = ["backports-datetime-fromisoformat ; python_version < \"3.11\"", "faust-cchardet (>=2.1.19)", "urllib3[brotli]"]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
 
 [[package]]
 name = "justext"
@@ -737,6 +762,18 @@ files = [
 lxml = "*"
 
 [[package]]
+name = "packaging"
+version = "26.2"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
+    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
+]
+
+[[package]]
 name = "pillow"
 version = "12.0.0"
 description = "Python Imaging Library (fork)"
@@ -846,6 +883,22 @@ tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "ole
 xmp = ["defusedxml"]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 description = "C parser in Python"
@@ -875,6 +928,21 @@ doc = ["sphinx", "sphinx_rtd_theme"]
 test = ["pillow", "pytest", "ruff"]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pyphen"
 version = "0.17.2"
 description = "Pure Python module to hyphenate text"
@@ -889,6 +957,28 @@ files = [
 [package.extras]
 doc = ["sphinx", "sphinx_rtd_theme"]
 test = ["pytest", "ruff"]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -1243,4 +1333,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14"
-content-hash = "fae386eb59fc70ad7305fd5b3dc9216550a8e4a85efc2913f00413c14f53eceb"
+content-hash = "b4d002f8a04a6fa2903aa2447ea262208852cac3bdd68e6a07fa88f67a63f4c8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,13 @@ dependencies = [
 [tool.poetry]
 package-mode = false
 
+[tool.poetry.group.dev.dependencies]
+# Pytest is the test runner invoked by tools/dependabot_review.py (in
+# AssemblyZero) as the test-must-pass gate. Without pytest in the venv,
+# the gate is vacuously inapplicable and every dependabot PR defers
+# forever. See issue #43.
+pytest = ">=8.0,<9.0"
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,58 @@
+"""Smoke tests: verify runtime dependencies can be imported / used.
+
+This is the minimum viable test gate for tools/dependabot_review.py's
+test-must-pass requirement. If a dependency upgrade breaks the import
+graph -- ABI break, transitive-dep incompatibility, removed API --
+these tests fail and the PR doesn't merge.
+
+Not a substitute for behavioral tests of the scripts themselves; those
+are out of scope (see issue #43 for the rationale).
+
+Pillow is the actual security-vuln target for most current dependabot
+PRs against this repo. It's pulled in transitively via weasyprint.
+We test Pillow directly (works on any machine) because the weasyprint
+import path requires GTK native libs which aren't always available --
+those imports skip gracefully on machines without GTK rather than
+failing the gate for an environment reason unrelated to dependency
+upgrades.
+"""
+
+import pytest
+
+
+def test_trafilatura_imports():
+    import trafilatura  # noqa: F401
+
+
+def test_tzdata_imports():
+    import tzdata  # noqa: F401
+
+
+def test_pillow_basic():
+    """Pillow drives weasyprint's image handling; test it directly.
+
+    Image.new + size check exercises the C extension's basic memory /
+    pixel-buffer paths. Any ABI break from a major bump (e.g. removed
+    deprecated constants, changed default modes) surfaces here.
+    """
+    from PIL import Image
+    img = Image.new("RGB", (10, 10), "red")
+    assert img.size == (10, 10)
+    assert img.mode == "RGB"
+
+
+def test_weasyprint_imports():
+    """Skip if GTK native libs (libgobject/libpango) aren't installed.
+
+    weasyprint requires GTK on Windows. On machines where GTK isn't
+    present, this test skips rather than fails -- the dependabot gate
+    should reflect "did the dep upgrade break Python imports", not
+    "is the user's machine fully set up for weasyprint runtime".
+    """
+    try:
+        import weasyprint  # noqa: F401
+    except OSError as e:
+        msg = str(e).lower()
+        if "libgobject" in msg or "libgtk" in msg or "libpango" in msg:
+            pytest.skip(f"GTK runtime not installed; weasyprint cannot import: {e}")
+        raise


### PR DESCRIPTION
## Summary

- Repo had zero tests and no pytest dep, so the fleet's `tools/dependabot_review.py` test-must-pass gate was vacuously inapplicable — every dependabot PR deferred forever, and 11 open security alerts were waiting on a gate they couldn't satisfy
- Adds `pytest` as a dev-group dep + `tests/test_imports.py` with smoke tests for the 3 runtime deps. Pillow tested directly via `Image.new` (catches ABI breaks); trafilatura + tzdata are import-only; weasyprint skips gracefully on machines without GTK runtime
- Verified locally: `poetry run pytest -q --tb=short` exits 0 (3 passed, 1 skipped). Same command the dependabot review tool invokes

## Test plan

- [x] `poetry run pytest -q --tb=short` exits 0 on a machine without GTK (3 passed, 1 skipped)
- [ ] After merge, dependabot rebases #29 onto the new main, then `tools/dependabot_review.py --fleet` should test against the new pyproject.toml (with pytest available) and merge if pillow 12.2.0 doesn't break the smoke tests

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)